### PR TITLE
Fix demon lord when healthbonus is undefined

### DIFF
--- a/scripts/systems/demonlord.js
+++ b/scripts/systems/demonlord.js
@@ -25,7 +25,7 @@ export default class DemonLordBar extends HPBarBase {
 
   prepareData() {
     const health = duplicate(super.data.characteristics.health);
-    const bonus = Number(super.data.characteristics.healthbonus);
+    const bonus = Number(super.data.characteristics.healthbonus ?? 0);
     const max = Number(health.max)
     const damage = Number(health.value)
 


### PR DESCRIPTION
By default, healthbonus is undefined in Demon Lord. So Arbron's Improved HP Bar doesn't work,