### PR TITLE
Add support for worldbuilding

### DIFF
--- a/module.json
+++ b/module.json
@@ -36,7 +36,8 @@
     "pf1",
     "pf2e",
     "ptu",
-    "tormenta20"
+    "tormenta20",
+    "worldbuilding"
   ],
   "relationships": {
     "systems": [
@@ -101,6 +102,13 @@
         "manifest": "https://gitlab.com/vizael/Tormenta20/-/raw/master/system.json",
         "compatibility": {
           "verified": "1.4.211"
+        }
+      },
+      {
+        "id": "worldbuilding",
+        "manifest": "https://raw.githubusercontent.com/foundryvtt/worldbuilding/master/system.json",
+        "compatibility": {
+          "verified": "0.8.2"
         }
       }
     ]

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ The default colors not working for you? Use the theme configurator to change the
 
 
 #### Supported Systems
-D&D [3.5e](https://foundryvtt.com/packages/D35E), [4e](https://foundryvtt.com/packages/dnd4e) & [5e](https://foundryvtt.com/packages/dnd5e), Pathfinder [1e](https://foundryvtt.com/packages/pf1) & [2e](https://foundryvtt.com/packages/pf2e), [Shadow of the Demon Lord](https://foundryvtt.com/packages/demonlord), [Toolkit13 (13th Age Compatible)](https://foundryvtt.com/packages/archmage), [Tormenta20](https://foundryvtt.com/packages/tormenta20), [Pokemon Tabletop United](https://github.com/dylanpiera/Foundry-Pokemon-Tabletop-United-System)
+D&D [3.5e](https://foundryvtt.com/packages/D35E), [4e](https://foundryvtt.com/packages/dnd4e) & [5e](https://foundryvtt.com/packages/dnd5e), Pathfinder [1e](https://foundryvtt.com/packages/pf1) & [2e](https://foundryvtt.com/packages/pf2e), [Shadow of the Demon Lord](https://foundryvtt.com/packages/demonlord), [Toolkit13 (13th Age Compatible)](https://foundryvtt.com/packages/archmage), [Tormenta20](https://foundryvtt.com/packages/tormenta20), [Pokemon Tabletop United](https://github.com/dylanpiera/Foundry-Pokemon-Tabletop-United-System), [Simple Worldbuilding System](https://foundryvtt.com/packages/worldbuilding)
 
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/I2I53RGZS)

--- a/scripts/systems/worldbuilding.mjs
+++ b/scripts/systems/worldbuilding.mjs
@@ -1,0 +1,36 @@
+import HPBarBase from './default.mjs';
+import * as utils from "../shared/utils.mjs";
+
+
+export default class WorldBuildingBar extends HPBarBase {
+  /** @inheritdoc */
+  static get themeOptions() {
+    return [
+      ...super.themeOptions,
+      HPBarBase._defaultTempTheme
+    ];
+  }
+
+  /** @inheritdoc */
+  static shouldDraw(attribute) {
+    return attribute === "health";
+  }
+
+  /** @inheritdoc */
+  prepareData() {
+    const _hp = utils.duplicate(this.system.health);
+    let data = {
+      max: Number(_hp.max),
+      value: Number(_hp.value),
+      temp: 0
+    };
+
+    // There is no temp health attribute by default, but custom attributes can be added, so check if one exists
+    if (Object.hasOwn(this.system.attributes, `tempHealth`) && this.system.attributes.tempHealth.dtype === `Number`) {
+      const _tmp = utils.duplicate(this.system.attributes.tempHealth);
+      data.temp = Number(_tmp.value);
+    }
+
+    return data;
+  }
+}


### PR DESCRIPTION
Add support for the Simple Worldbuilding System

Note that this system doesn't support temp HP by default, but the default actor sheet allows custom attributes to be added, so I simply checked for a custom "tempHealth" attribute. This works well enough for my own personal game in Foundry, but may or may not be something you want to officially support.